### PR TITLE
Metrics name consistency (oracle_tablespace -> oracledb_tablespace).

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The following metrics are exposed currently.
 - oracledb_wait_time_scheduler
 - oracledb_wait_time_system_io
 - oracledb_wait_time_user_io
-- oracle_tablespace_bytes
-- oracle_tablespace_max_bytes
-- oracle_tablespace_bytes_free
+- oracledb_tablespace_bytes
+- oracledb_tablespace_max_bytes
+- oracledb_tablespace_bytes_free
 
 # Installation
 

--- a/main.go
+++ b/main.go
@@ -345,17 +345,17 @@ ORDER BY
 	}
 	defer rows.Close()
 	tablespaceBytesDesc := prometheus.NewDesc(
-		"oracle_tablespace_bytes",
+		prometheus.BuildFQName(namespace, "tablespace", "bytes"),
 		"Generic counter metric of tablespaces bytes in Oracle.",
 		[]string{"tablespace", "type"}, nil,
 	)
 	tablespaceMaxBytesDesc := prometheus.NewDesc(
-		"oracle_tablespace_max_bytes",
+		prometheus.BuildFQName(namespace, "tablespace", "max_bytes"),
 		"Generic counter metric of tablespaces max bytes in Oracle.",
 		[]string{"tablespace", "type"}, nil,
 	)
 	tablespaceFreeBytesDesc := prometheus.NewDesc(
-		"oracle_tablespace_bytes_free",
+		prometheus.BuildFQName(namespace, "tablespace", "free"),
 		"Generic counter metric of tablespaces free bytes in Oracle.",
 		[]string{"tablespace", "type"}, nil,
 	)


### PR DESCRIPTION
Rename newly introduced metrics to get more consistency.