### PR TITLE
Introducing multiplexing oracle instance monitoring :

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Pre-compiled versions for Linux 64 bit and Mac OSX 64 bit can be found under [re
 
 In order to run, you'll need the [Oracle Instant Client Basic](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html) for your operating system. Only the basic version is required for execution.
 
-# Running the Binary
+# Running the Binary with DATA_SOURCE_NAME variable
 
 Ensure that the environment variable DATA_SOURCE_NAME is set correctly before starting. For Example
 
@@ -57,18 +57,64 @@ export DATA_SOURCE_NAME=system/oracle@myhost
 /path/to/binary -l log.level error -l web.listen-address 9161
 ```
 
+# Running the Binary with config file
+
+Another way to launch the binary is to use a directory where you store your configuration in **poml** file. If you provide more than one file, this exporter load them all. It's a convenient way to multiplex your Oracle monitoring when you've got more than one Oracle instance on a server.
+
+There's two examples in ``config-example``. In this file, you can provide each values on separate fields like this:
+
+```
+user="system"
+pass="temppasswd"
+host="localhost"
+port="1521"
+service="XE"
+```
+
+**host** and **port** are not required and use default value (localhost and 1521). You can change this default value using --listener-address and --listener-port options.
+
+You can also provide only string field with all informations:
+
+```
+string="system/temppasswd@localhost:1521/XE"
+```
+
+By default, this exporter add a name label using the filename (without the extension). If you want to change this label, you can use **name** field with the value you wan't:
+
+```
+name="DEMO"
+```
+
+Here is an example using one config file for **oracledb_sessions_active**:
+
+```
+# HELP oracledb_sessions_active Gauge metric with count of sessions marked ACTIVE
+# TYPE oracledb_sessions_active gauge
+oracledb_sessions_active{name="XE"} 41
+```
+
+Same metrics with two config file (XE.poml and DEMO.poml):
+```
+# HELP oracledb_sessions_active Gauge metric with count of sessions marked ACTIVE
+# TYPE oracledb_sessions_active gauge
+oracledb_sessions_active{name="DEMO"} 41
+oracledb_sessions_active{name="XE"} 31
+```
+
 ## Usage
 
 ```bash
 Usage of oracledb_exporter:
-  -log.format value
-       	If set use a syslog logger or JSON logging. Example: logger:syslog?appname=bob&local=7 or logger:stdout?json=true. Defaults to stderr.
-  -log.level value
-       	Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal].
+  -config-dir string
+        Directory where we store config. Each file result in map
+  -listener-address string
+        Default Oracle listener address (default "localhost")
+  -listener-port string
+        Default Oracle listener port (default "1521")
   -web.listen-address string
-       	Address to listen on for web interface and telemetry. (default ":9161")
+        Address to listen on for web interface and telemetry. (default ":9161")
   -web.telemetry-path string
-       	Path under which to expose metrics. (default "/metrics")
+        Path under which to expose metrics. (default "/metrics")
 ```
 
 # Integration with Grafana

--- a/config-example/DOCKER.toml
+++ b/config-example/DOCKER.toml
@@ -1,0 +1,5 @@
+user="system"
+pass="temppasswd"
+host="demora1"
+port="1521"
+service="DOCKER"

--- a/config-example/MONO12C.toml
+++ b/config-example/MONO12C.toml
@@ -1,0 +1,4 @@
+# Use a string to define connection with a port
+string="system/temppasswd@demora2:1522/MONO12C"
+# You can change displayed value for whatever you want
+name="DEMO2"

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1,0 +1,388 @@
+package exporter
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-oci8"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+// Metric name parts.
+const (
+	namespace = "oracledb"
+	exporter  = "exporter"
+)
+
+// Exporter collects Oracle DB metrics. It implements prometheus.Collector.
+type Exporter struct {
+	dsn             string
+	labels          prometheus.Labels
+	duration, error prometheus.Gauge
+	totalScrapes    prometheus.Counter
+	scrapeErrors    *prometheus.CounterVec
+	up              prometheus.Gauge
+}
+
+// NewExporter returns a new Oracle DB exporter for the provided DSN.
+func NewExporter(dsn string, name string) *Exporter {
+	labels := prometheus.Labels{ "Name": name }
+	exporter := &Exporter{
+		dsn: dsn,
+		labels: labels,
+		duration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "last_scrape_duration_seconds",
+			Help:      "Duration of the last scrape of metrics from Oracle DB.",
+			ConstLabels: labels,
+		}),
+		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "scrapes_total",
+			Help:      "Total number of times Oracle DB was scraped for metrics.",
+			ConstLabels: labels,
+		}),
+		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "scrape_errors_total",
+			Help:      "Total number of times an error occured scraping a Oracle database.",
+			ConstLabels: labels,
+		}, []string{"collector"}),
+		error: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "last_scrape_error",
+			Help:      "Whether the last scrape of metrics from Oracle DB resulted in an error (1 for error, 0 for success).",
+			ConstLabels: labels,
+		}),
+		up: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "up",
+			Help:      "Whether the Oracle database server is up.",
+			ConstLabels: labels,
+		}),
+	}
+	prometheus.MustRegister(exporter)
+	return exporter
+}
+
+// Describe describes all the metrics exported by the Oracle exporter.
+func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
+	// We cannot know in advance what metrics the exporter will generate
+	// So we use the poor man's describe method: Run a collect
+	// and send the descriptors of all the collected metrics. The problem
+	// here is that we need to connect to the Oracle DB. If it is currently
+	// unavailable, the descriptors will be incomplete. Since this is a
+	// stand-alone exporter and not used as a library within other code
+	// implementing additional metrics, the worst that can happen is that we
+	// don't detect inconsistent metrics created by this exporter
+	// itself. Also, a change in the monitored Oracle instance may change the
+	// exported metrics during the runtime of the exporter.
+
+	metricCh := make(chan prometheus.Metric)
+	doneCh := make(chan struct{})
+
+	go func() {
+		for m := range metricCh {
+			ch <- m.Desc()
+		}
+		close(doneCh)
+	}()
+
+	e.Collect(metricCh)
+	close(metricCh)
+	<-doneCh
+
+}
+
+// Collect implements prometheus.Collector.
+func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	e.scrape(ch)
+	ch <- e.duration
+	ch <- e.totalScrapes
+	ch <- e.error
+	e.scrapeErrors.Collect(ch)
+	ch <- e.up
+}
+
+func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
+	e.totalScrapes.Inc()
+	var err error
+	defer func(begun time.Time) {
+		e.duration.Set(time.Since(begun).Seconds())
+		if err == nil {
+			e.error.Set(0)
+		} else {
+			e.error.Set(1)
+		}
+	}(time.Now())
+
+	db, err := sql.Open("oci8", e.dsn)
+	if err != nil {
+		log.Errorln("Error opening connection to database:", err)
+		return
+	}
+	defer db.Close()
+
+	isUpRows, err := db.Query("SELECT 1 FROM DUAL")
+	if err != nil {
+		log.Errorln("Error pinging oracle:", err)
+		e.up.Set(0)
+		return
+	}
+	isUpRows.Close()
+	e.up.Set(1)
+
+	if err = e.ScrapeActivity(db, ch); err != nil {
+		log.Errorln("Error scraping for activity:", err)
+		e.scrapeErrors.WithLabelValues("activity").Inc()
+	}
+
+	if err = e.ScrapeTablespace(db, ch); err != nil {
+		log.Errorln("Error scraping for tablespace:", err)
+		e.scrapeErrors.WithLabelValues("tablespace").Inc()
+  }
+
+	if err = e.ScrapeWaitTime(db, ch); err != nil {
+		log.Errorln("Error scraping for wait_time:", err)
+		e.scrapeErrors.WithLabelValues("wait_time").Inc()
+	}
+
+	if err = e.ScrapeSessions(db, ch); err != nil {
+		log.Errorln("Error scraping for sessions:", err)
+		e.scrapeErrors.WithLabelValues("sessions").Inc()
+	}
+}
+
+// ScrapeSessions collects session metrics from the v$session view.
+func (e *Exporter) ScrapeSessions(db *sql.DB, ch chan<- prometheus.Metric) error {
+	var err error
+	var activeCount float64
+	var inactiveCount float64
+
+	// There is probably a better way to do this with a single query. #FIXME when I figure that out.
+	err = db.QueryRow("SELECT COUNT(*) FROM v$session WHERE status = 'ACTIVE'").Scan(&activeCount)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(prometheus.BuildFQName(namespace, "sessions", "active"),
+			"Gauge metric with count of sessions marked ACTIVE", []string{}, e.labels),
+		prometheus.GaugeValue,
+		activeCount,
+	)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM v$session WHERE status = 'INACTIVE'").Scan(&inactiveCount)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(prometheus.BuildFQName(namespace, "sessions", "inactive"),
+			"Gauge metric with count of sessions marked INACTIVE.", []string{}, e.labels),
+		prometheus.GaugeValue,
+		inactiveCount,
+	)
+
+	return nil
+}
+
+// ScrapeWaitTime collects wait time metrics from the v$waitclassmetric view.
+func (e *Exporter) ScrapeWaitTime(db *sql.DB, ch chan<- prometheus.Metric) error {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	rows, err = db.Query("SELECT n.wait_class, round(m.time_waited/m.INTSIZE_CSEC,3) AAS from v$waitclassmetric  m, v$system_wait_class n where m.wait_class_id=n.wait_class_id and n.wait_class != 'Idle'")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		var value float64
+		if err := rows.Scan(&name, &value); err != nil {
+			return err
+		}
+		name = cleanName(name)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, "wait_time", name),
+				"Generic counter metric from v$waitclassmetric view in Oracle.", []string{}, e.labels),
+			prometheus.CounterValue,
+			value,
+		)
+	}
+	return nil
+}
+
+// ScrapeActivity collects activity metrics from the v$sysstat view.
+func (e *Exporter) ScrapeActivity(db *sql.DB, ch chan<- prometheus.Metric) error {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	rows, err = db.Query("SELECT name, value FROM v$sysstat WHERE name IN ('parse count (total)', 'execute count', 'user commits', 'user rollbacks')")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		var value float64
+		if err := rows.Scan(&name, &value); err != nil {
+			return err
+		}
+		name = cleanName(name)
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, "activity", name),
+				"Generic counter metric from v$sysstat view in Oracle.", []string{}, e.labels),
+			prometheus.CounterValue,
+			value,
+		)
+	}
+	return nil
+}
+
+// ScrapeTablespace collects tablespace size.
+func (e *Exporter) ScrapeTablespace(db *sql.DB, ch chan<- prometheus.Metric) error {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	rows, err = db.Query(`SELECT
+    a.tablespace_name         "Tablespace",
+    b.status                  "Status",
+    b.contents                "Type",
+    b.extent_management       "Extent Mgmt",
+    a.bytes                   bytes,
+    a.maxbytes                bytes_max,
+    c.bytes_free + NVL(d.bytes_expired,0)  bytes_free
+FROM
+  (
+    -- belegter und maximal verfuegbarer platz pro datafile
+    -- nach tablespacenamen zusammengefasst
+    -- => bytes
+    -- => maxbytes
+    SELECT
+        a.tablespace_name,
+        SUM(a.bytes)          bytes,
+        SUM(DECODE(a.autoextensible, 'YES', a.maxbytes, 'NO', a.bytes)) maxbytes
+    FROM
+        dba_data_files a
+    GROUP BY
+        tablespace_name
+  ) a,
+  sys.dba_tablespaces b,
+  (
+    -- freier platz pro tablespace
+    -- => bytes_free
+    SELECT
+        a.tablespace_name,
+        SUM(a.bytes) bytes_free
+    FROM
+        dba_free_space a
+    GROUP BY
+        tablespace_name
+  ) c,
+  (
+    -- freier platz durch expired extents
+    -- speziell fuer undo tablespaces
+    -- => bytes_expired
+    SELECT
+        a.tablespace_name,
+        SUM(a.bytes) bytes_expired
+    FROM
+        dba_undo_extents a
+    WHERE
+        status = 'EXPIRED'
+    GROUP BY
+        tablespace_name
+  ) d
+WHERE
+    a.tablespace_name = c.tablespace_name (+)
+    AND a.tablespace_name = b.tablespace_name
+    AND a.tablespace_name = d.tablespace_name (+)
+UNION ALL
+SELECT
+    d.tablespace_name "Tablespace",
+    b.status "Status",
+    b.contents "Type",
+    b.extent_management "Extent Mgmt",
+    sum(a.bytes_free + a.bytes_used) bytes,   -- allocated
+    SUM(DECODE(d.autoextensible, 'YES', d.maxbytes, 'NO', d.bytes)) bytes_max,
+    SUM(a.bytes_free + a.bytes_used - NVL(c.bytes_used, 0)) bytes_free
+FROM
+    sys.v_$TEMP_SPACE_HEADER a,
+    sys.dba_tablespaces b,
+    sys.v_$Temp_extent_pool c,
+    dba_temp_files d
+WHERE
+    c.file_id(+)             = a.file_id
+    and c.tablespace_name(+) = a.tablespace_name
+    and d.file_id            = a.file_id
+    and d.tablespace_name    = a.tablespace_name
+    and b.tablespace_name    = a.tablespace_name
+GROUP BY
+    b.status,
+    b.contents,
+    b.extent_management,
+    d.tablespace_name
+ORDER BY
+    1
+`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	tablespaceBytesDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "tablespace", "bytes"),
+		"Generic counter metric of tablespaces bytes in Oracle.",
+		[]string{"tablespace", "type"}, e.labels,
+	)
+	tablespaceMaxBytesDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "tablespace", "max_bytes"),
+		"Generic counter metric of tablespaces max bytes in Oracle.",
+		[]string{"tablespace", "type"}, e.labels,
+	)
+	tablespaceFreeBytesDesc := prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "tablespace", "free"),
+		"Generic counter metric of tablespaces free bytes in Oracle.",
+		[]string{"tablespace", "type"}, e.labels,
+	)
+
+	for rows.Next() {
+		var tablespace_name string
+		var status string
+		var contents string
+		var extent_management string
+		var bytes float64
+		var max_bytes float64
+		var bytes_free float64
+
+		if err := rows.Scan(&tablespace_name, &status, &contents, &extent_management, &bytes, &max_bytes, &bytes_free); err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(tablespaceBytesDesc,     prometheus.GaugeValue, float64(bytes),      tablespace_name, contents)
+		ch <- prometheus.MustNewConstMetric(tablespaceMaxBytesDesc,  prometheus.GaugeValue, float64(max_bytes),  tablespace_name, contents)
+		ch <- prometheus.MustNewConstMetric(tablespaceFreeBytesDesc, prometheus.GaugeValue, float64(bytes_free), tablespace_name, contents)
+	}
+	return nil
+}
+
+// Oracle gives us some ugly names back. This function cleans things up for Prometheus.
+func cleanName(s string) string {
+	s = strings.Replace(s, " ", "_", -1) // Remove spaces
+	s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
+	s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
+	s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
+	s = strings.ToLower(s)
+	return s
+}

--- a/main.go
+++ b/main.go
@@ -1,17 +1,21 @@
 package main
 
 import (
-	"database/sql"
 	"flag"
 	"net/http"
 	"os"
+	"io/ioutil"
+	"github.com/BurntSushi/toml"
 	"strings"
-	"time"
-
-	_ "github.com/mattn/go-oci8"
+  "./exporter"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
+)
+
+const (
+	pageHeader = "<html><head><title>Oracle DB exporter</title></head><body><h1>Oracle DB exporter</h1>"
+	pageFooter = "</body></html>"
 )
 
 var (
@@ -19,382 +23,56 @@ var (
 	Version       = "0.0.0.dev"
 	listenAddress = flag.String("web.listen-address", ":9161", "Address to listen on for web interface and telemetry.")
 	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-	landingPage   = []byte("<html><head><title>Oracle DB exporter</title></head><body><h1>Oracle DB exporter</h1><p><a href='" + *metricPath + "'>Metrics</a></p></body></html>")
+	landingPage   = []byte(pageHeader + "<p><a href='" + *metricPath + "'>Metrics</a></p>" + pageFooter)
+	readConfigDir = flag.String("config-dir", "", "Directory where we store file config.")
+	listenerPort  = flag.String("listener-port", "1521", "Default Oracle listener port.")
+	listenerAddr  = flag.String("listener-address", "localhost", "Default Oracle listener address.")
 )
 
-// Metric name parts.
-const (
-	namespace = "oracledb"
-	exporter  = "exporter"
-)
-
-// Exporter collects Oracle DB metrics. It implements prometheus.Collector.
-type Exporter struct {
-	dsn             string
-	duration, error prometheus.Gauge
-	totalScrapes    prometheus.Counter
-	scrapeErrors    *prometheus.CounterVec
-	up              prometheus.Gauge
+type DBConfig struct {
+	Name string
+	String string
+	User string
+	Pass string
+	Host string
+	Port string
+	Service string
 }
 
-// NewExporter returns a new Oracle DB exporter for the provided DSN.
-func NewExporter(dsn string) *Exporter {
-	return &Exporter{
-		dsn: dsn,
-		duration: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "last_scrape_duration_seconds",
-			Help:      "Duration of the last scrape of metrics from Oracle DB.",
-		}),
-		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "scrapes_total",
-			Help:      "Total number of times Oracle DB was scraped for metrics.",
-		}),
-		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "scrape_errors_total",
-			Help:      "Total number of times an error occured scraping a Oracle database.",
-		}, []string{"collector"}),
-		error: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "last_scrape_error",
-			Help:      "Whether the last scrape of metrics from Oracle DB resulted in an error (1 for error, 0 for success).",
-		}),
-		up: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "up",
-			Help:      "Whether the Oracle database server is up.",
-		}),
+func loadConfigFile(path string, file string) (string, string) {
+	name := strings.TrimSuffix(file, ".toml")
+	var cfg DBConfig
+	_, err := toml.DecodeFile(path + "/" + file, &cfg)
+	if err != nil { panic(err) }
+	// Read name from file or use filename prefix
+	if cfg.Name == "" { cfg.Name = name }
+	// get connection string or construct it
+	oracleConnectionString := cfg.String
+	if oracleConnectionString == "" {
+		// default value
+		if cfg.Host == "" { cfg.Host = *listenerAddr }
+		if cfg.Port == "" { cfg.Port = *listenerPort }
+		oracleConnectionString = cfg.User + "/" + cfg.Pass + "@" + cfg.Host + ":" + cfg.Port + "/" + cfg.Service
 	}
-}
-
-// Describe describes all the metrics exported by the MS SQL exporter.
-func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	// We cannot know in advance what metrics the exporter will generate
-	// So we use the poor man's describe method: Run a collect
-	// and send the descriptors of all the collected metrics. The problem
-	// here is that we need to connect to the Oracle DB. If it is currently
-	// unavailable, the descriptors will be incomplete. Since this is a
-	// stand-alone exporter and not used as a library within other code
-	// implementing additional metrics, the worst that can happen is that we
-	// don't detect inconsistent metrics created by this exporter
-	// itself. Also, a change in the monitored Oracle instance may change the
-	// exported metrics during the runtime of the exporter.
-
-	metricCh := make(chan prometheus.Metric)
-	doneCh := make(chan struct{})
-
-	go func() {
-		for m := range metricCh {
-			ch <- m.Desc()
-		}
-		close(doneCh)
-	}()
-
-	e.Collect(metricCh)
-	close(metricCh)
-	<-doneCh
-
-}
-
-// Collect implements prometheus.Collector.
-func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	e.scrape(ch)
-	ch <- e.duration
-	ch <- e.totalScrapes
-	ch <- e.error
-	e.scrapeErrors.Collect(ch)
-	ch <- e.up
-}
-
-func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
-	e.totalScrapes.Inc()
-	var err error
-	defer func(begun time.Time) {
-		e.duration.Set(time.Since(begun).Seconds())
-		if err == nil {
-			e.error.Set(0)
-		} else {
-			e.error.Set(1)
-		}
-	}(time.Now())
-
-	db, err := sql.Open("oci8", e.dsn)
-	if err != nil {
-		log.Errorln("Error opening connection to database:", err)
-		return
-	}
-	defer db.Close()
-
-	isUpRows, err := db.Query("SELECT 1 FROM DUAL")
-	if err != nil {
-		log.Errorln("Error pinging oracle:", err)
-		e.up.Set(0)
-		return
-	}
-	isUpRows.Close()
-	e.up.Set(1)
-
-	if err = ScrapeActivity(db, ch); err != nil {
-		log.Errorln("Error scraping for activity:", err)
-		e.scrapeErrors.WithLabelValues("activity").Inc()
-	}
-
-	if err = ScrapeTablespace(db, ch); err != nil {
-		log.Errorln("Error scraping for tablespace:", err)
-		e.scrapeErrors.WithLabelValues("tablespace").Inc()
-  }
-
-	if err = ScrapeWaitTime(db, ch); err != nil {
-		log.Errorln("Error scraping for wait_time:", err)
-		e.scrapeErrors.WithLabelValues("wait_time").Inc()
-	}
-
-	if err = ScrapeSessions(db, ch); err != nil {
-		log.Errorln("Error scraping for sessions:", err)
-		e.scrapeErrors.WithLabelValues("sessions").Inc()
-	}
-
-}
-
-// ScrapeSessions collects session metrics from the v$session view.
-func ScrapeSessions(db *sql.DB, ch chan<- prometheus.Metric) error {
-	var err error
-	var activeCount float64
-	var inactiveCount float64
-
-	// There is probably a better way to do this with a single query. #FIXME when I figure that out.
-	err = db.QueryRow("SELECT COUNT(*) FROM v$session WHERE status = 'ACTIVE'").Scan(&activeCount)
-	if err != nil {
-		return err
-	}
-
-	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(prometheus.BuildFQName(namespace, "sessions", "active"),
-			"Gauge metric with count of sessions marked ACTIVE", []string{}, nil),
-		prometheus.GaugeValue,
-		activeCount,
-	)
-
-	err = db.QueryRow("SELECT COUNT(*) FROM v$session WHERE status = 'INACTIVE'").Scan(&inactiveCount)
-	if err != nil {
-		return err
-	}
-
-	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(prometheus.BuildFQName(namespace, "sessions", "inactive"),
-			"Gauge metric with count of sessions marked INACTIVE.", []string{}, nil),
-		prometheus.GaugeValue,
-		inactiveCount,
-	)
-
-	return nil
-}
-
-// ScrapeWaitTime collects wait time metrics from the v$waitclassmetric view.
-func ScrapeWaitTime(db *sql.DB, ch chan<- prometheus.Metric) error {
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	rows, err = db.Query("SELECT n.wait_class, round(m.time_waited/m.INTSIZE_CSEC,3) AAS from v$waitclassmetric  m, v$system_wait_class n where m.wait_class_id=n.wait_class_id and n.wait_class != 'Idle'")
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var name string
-		var value float64
-		if err := rows.Scan(&name, &value); err != nil {
-			return err
-		}
-		name = cleanName(name)
-		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(prometheus.BuildFQName(namespace, "wait_time", name),
-				"Generic counter metric from v$waitclassmetric view in Oracle.", []string{}, nil),
-			prometheus.CounterValue,
-			value,
-		)
-	}
-	return nil
-}
-
-// ScrapeActivity collects activity metrics from the v$sysstat view.
-func ScrapeActivity(db *sql.DB, ch chan<- prometheus.Metric) error {
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	rows, err = db.Query("SELECT name, value FROM v$sysstat WHERE name IN ('parse count (total)', 'execute count', 'user commits', 'user rollbacks')")
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var name string
-		var value float64
-		if err := rows.Scan(&name, &value); err != nil {
-			return err
-		}
-		name = cleanName(name)
-		ch <- prometheus.MustNewConstMetric(
-			prometheus.NewDesc(prometheus.BuildFQName(namespace, "activity", name),
-				"Generic counter metric from v$sysstat view in Oracle.", []string{}, nil),
-			prometheus.CounterValue,
-			value,
-		)
-	}
-	return nil
-}
-
-// ScrapeTablespace collects tablespace size.
-func ScrapeTablespace(db *sql.DB, ch chan<- prometheus.Metric) error {
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	rows, err = db.Query(`SELECT
-    a.tablespace_name         "Tablespace",
-    b.status                  "Status",
-    b.contents                "Type",
-    b.extent_management       "Extent Mgmt",
-    a.bytes                   bytes,
-    a.maxbytes                bytes_max,
-    c.bytes_free + NVL(d.bytes_expired,0)  bytes_free
-FROM
-  (
-    -- belegter und maximal verfuegbarer platz pro datafile
-    -- nach tablespacenamen zusammengefasst
-    -- => bytes
-    -- => maxbytes
-    SELECT
-        a.tablespace_name,
-        SUM(a.bytes)          bytes,
-        SUM(DECODE(a.autoextensible, 'YES', a.maxbytes, 'NO', a.bytes)) maxbytes
-    FROM
-        dba_data_files a
-    GROUP BY
-        tablespace_name
-  ) a,
-  sys.dba_tablespaces b,
-  (
-    -- freier platz pro tablespace
-    -- => bytes_free
-    SELECT
-        a.tablespace_name,
-        SUM(a.bytes) bytes_free
-    FROM
-        dba_free_space a
-    GROUP BY
-        tablespace_name
-  ) c,
-  (
-    -- freier platz durch expired extents
-    -- speziell fuer undo tablespaces
-    -- => bytes_expired
-    SELECT
-        a.tablespace_name,
-        SUM(a.bytes) bytes_expired
-    FROM
-        dba_undo_extents a
-    WHERE
-        status = 'EXPIRED'
-    GROUP BY
-        tablespace_name
-  ) d
-WHERE
-    a.tablespace_name = c.tablespace_name (+)
-    AND a.tablespace_name = b.tablespace_name
-    AND a.tablespace_name = d.tablespace_name (+)
-UNION ALL
-SELECT
-    d.tablespace_name "Tablespace",
-    b.status "Status",
-    b.contents "Type",
-    b.extent_management "Extent Mgmt",
-    sum(a.bytes_free + a.bytes_used) bytes,   -- allocated
-    SUM(DECODE(d.autoextensible, 'YES', d.maxbytes, 'NO', d.bytes)) bytes_max,
-    SUM(a.bytes_free + a.bytes_used - NVL(c.bytes_used, 0)) bytes_free
-FROM
-    sys.v_$TEMP_SPACE_HEADER a,
-    sys.dba_tablespaces b,
-    sys.v_$Temp_extent_pool c,
-    dba_temp_files d
-WHERE
-    c.file_id(+)             = a.file_id
-    and c.tablespace_name(+) = a.tablespace_name
-    and d.file_id            = a.file_id
-    and d.tablespace_name    = a.tablespace_name
-    and b.tablespace_name    = a.tablespace_name
-GROUP BY
-    b.status,
-    b.contents,
-    b.extent_management,
-    d.tablespace_name
-ORDER BY
-    1
-`)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-	tablespaceBytesDesc := prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "tablespace", "bytes"),
-		"Generic counter metric of tablespaces bytes in Oracle.",
-		[]string{"tablespace", "type"}, nil,
-	)
-	tablespaceMaxBytesDesc := prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "tablespace", "max_bytes"),
-		"Generic counter metric of tablespaces max bytes in Oracle.",
-		[]string{"tablespace", "type"}, nil,
-	)
-	tablespaceFreeBytesDesc := prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "tablespace", "free"),
-		"Generic counter metric of tablespaces free bytes in Oracle.",
-		[]string{"tablespace", "type"}, nil,
-	)
-
-	for rows.Next() {
-		var tablespace_name string
-		var status string
-		var contents string
-		var extent_management string
-		var bytes float64
-		var max_bytes float64
-		var bytes_free float64
-
-		if err := rows.Scan(&tablespace_name, &status, &contents, &extent_management, &bytes, &max_bytes, &bytes_free); err != nil {
-			return err
-		}
-		ch <- prometheus.MustNewConstMetric(tablespaceBytesDesc,     prometheus.GaugeValue, float64(bytes),      tablespace_name, contents)
-		ch <- prometheus.MustNewConstMetric(tablespaceMaxBytesDesc,  prometheus.GaugeValue, float64(max_bytes),  tablespace_name, contents)
-		ch <- prometheus.MustNewConstMetric(tablespaceFreeBytesDesc, prometheus.GaugeValue, float64(bytes_free), tablespace_name, contents)
-	}
-	return nil
-}
-
-// Oracle gives us some ugly names back. This function cleans things up for Prometheus.
-func cleanName(s string) string {
-	s = strings.Replace(s, " ", "_", -1) // Remove spaces
-	s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
-	s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
-	s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
-	s = strings.ToLower(s)
-	return s
+	return cfg.Name, oracleConnectionString
 }
 
 func main() {
 	flag.Parse()
 	log.Infoln("Starting oracledb_exporter " + Version)
-	dsn := os.Getenv("DATA_SOURCE_NAME")
-	exporter := NewExporter(dsn)
-	prometheus.MustRegister(exporter)
+	if *readConfigDir == "" {
+		exporter.NewExporter(os.Getenv("DATA_SOURCE_NAME"), "default")
+	} else {
+		files, err := ioutil.ReadDir(*readConfigDir)
+		if err != nil { panic(err) }
+		for _, f := range files {
+			if strings.HasSuffix(f.Name(), ".toml") {
+				name, connectionString := loadConfigFile(*readConfigDir, f.Name())
+				log.Infoln("New Oracle instance detected: " + name)
+				exporter.NewExporter(connectionString, name)
+			}
+		}
+	}
 	http.Handle(*metricPath, prometheus.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(landingPage)


### PR DESCRIPTION
This PR introduce a way to multiplexe oracle instance monitoring when using multiple Oracle instance on a single machine.

- Move monitoring logic from main.go to exporter/exporter.go.
- Add new option --config-dir to specify where we store config file.
- Examples of config file in config-example.
