### PR TITLE
Query timeout envvar

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -37,7 +37,7 @@ ENV LD_LIBRARY_PATH /usr/lib/oracle/18.3/client64/lib
 COPY --from=build $LD_LIBRARY_PATH $LD_LIBRARY_PATH
 COPY --from=build /go/src/oracledb_exporter/oracledb_exporter /oracledb_exporter
 COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/glibc-compat/lib
-COPY --from=build /lib/x86_64-linux-gnu/libaio.so.1 /usr/glibc-compat/lib
+COPY --from=build /usr/lib/x86_64-linux-gnu/libaio.so.1 /usr/glibc-compat/lib
 ADD ./default-metrics.toml /default-metrics.toml
 
 ENV DATA_SOURCE_NAME system/oracle@oracle/xe

--- a/main.go
+++ b/main.go
@@ -1,359 +1,366 @@
 package main
 
 import (
-  "database/sql"
-  "flag"
-  "net/http"
-  "os"
-  "strings"
-  "strconv"
-  "time"
-  "errors"
-  "context"
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
-  "github.com/BurntSushi/toml"
+	"github.com/BurntSushi/toml"
 
-  _ "github.com/mattn/go-oci8"
+	_ "github.com/mattn/go-oci8"
 
-  "github.com/prometheus/client_golang/prometheus"
-  "github.com/prometheus/common/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 var (
-  // Version will be set at build time.
-  Version       = "0.0.0.dev"
-  listenAddress = flag.String("web.listen-address", ":9161", "Address to listen on for web interface and telemetry.")
-  metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
-  landingPage   = []byte("<html><head><title>Oracle DB Exporter " + Version + "</title></head><body><h1>Oracle DB Exporter " + Version + "</h1><p><a href='" + *metricPath + "'>Metrics</a></p></body></html>")
-  defaultFileMetrics = flag.String("default.metrics", "default-metrics.toml", "File with default metrics in a TOML file.")
-  customMetrics = flag.String("custom.metrics", os.Getenv("CUSTOM_METRICS"), "File that may contain various custom metrics in a TOML file.")
-  queryTimeout  = flag.String("query.timeout", "5", "Query timeout (in seconds).")
+	// Version will be set at build time.
+	Version            = "0.0.0.dev"
+	listenAddress      = flag.String("web.listen-address", ":9161", "Address to listen on for web interface and telemetry.")
+	metricPath         = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	landingPage        = []byte("<html><head><title>Oracle DB Exporter " + Version + "</title></head><body><h1>Oracle DB Exporter " + Version + "</h1><p><a href='" + *metricPath + "'>Metrics</a></p></body></html>")
+	defaultFileMetrics = flag.String("default.metrics", "default-metrics.toml", "File with default metrics in a TOML file.")
+	customMetrics      = flag.String("custom.metrics", os.Getenv("CUSTOM_METRICS"), "File that may contain various custom metrics in a TOML file. (env: CUSTOM_METRICS)")
+	queryTimeout       = flag.String("query.timeout", getEnv("QUERY_TIMEOUT", "5"), "Query timeout (in seconds). (env: QUERY_TIMEOUT)")
 )
 
 // Metric name parts.
 const (
-  namespace = "oracledb"
-  exporter  = "exporter"
+	namespace = "oracledb"
+	exporter  = "exporter"
 )
 
 // Metrics object description
 type Metric struct {
-  Context       string
-  Labels        []string
-  MetricsDesc   map[string]string
-  MetricsType   map[string]string
-  FieldToAppend string
-  Request       string
-  IgnoreZeroResult bool
+	Context          string
+	Labels           []string
+	MetricsDesc      map[string]string
+	MetricsType      map[string]string
+	FieldToAppend    string
+	Request          string
+	IgnoreZeroResult bool
 }
 
 // Used to load multiple metrics from file
 type Metrics struct {
-  Metric []Metric
+	Metric []Metric
 }
 
 // Metrics to scrap. Use external file (default-metrics.toml and custom if provided)
 var (
-  metricsToScrap Metrics
-  additionalMetrics Metrics
+	metricsToScrap    Metrics
+	additionalMetrics Metrics
 )
 
 // Exporter collects Oracle DB metrics. It implements prometheus.Collector.
 type Exporter struct {
-  dsn             string
-  duration, error prometheus.Gauge
-  totalScrapes    prometheus.Counter
-  scrapeErrors    *prometheus.CounterVec
-  up              prometheus.Gauge
-  db              *sql.DB
+	dsn             string
+	duration, error prometheus.Gauge
+	totalScrapes    prometheus.Counter
+	scrapeErrors    *prometheus.CounterVec
+	up              prometheus.Gauge
+	db              *sql.DB
+}
 
+// getEnv returns the value of an environment variable, or returns the provided fallback value
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }
 
 // NewExporter returns a new Oracle DB exporter for the provided DSN.
 func NewExporter(dsn string) *Exporter {
-  db, err := sql.Open("oci8", dsn)
-  if err != nil {
-    log.Errorln("Error while connecting to", dsn)
-    panic(err)
-  }
-  return &Exporter{
-    dsn: dsn,
-    duration: prometheus.NewGauge(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "last_scrape_duration_seconds",
-      Help:      "Duration of the last scrape of metrics from Oracle DB.",
-    }),
-    totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "scrapes_total",
-      Help:      "Total number of times Oracle DB was scraped for metrics.",
-    }),
-    scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "scrape_errors_total",
-      Help:      "Total number of times an error occured scraping a Oracle database.",
-    }, []string{"collector"}),
-    error: prometheus.NewGauge(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Subsystem: exporter,
-      Name:      "last_scrape_error",
-      Help:      "Whether the last scrape of metrics from Oracle DB resulted in an error (1 for error, 0 for success).",
-    }),
-    up: prometheus.NewGauge(prometheus.GaugeOpts{
-      Namespace: namespace,
-      Name:      "up",
-      Help:      "Whether the Oracle database server is up.",
-    }),
-    db: db,
-  }
+	db, err := sql.Open("oci8", dsn)
+	if err != nil {
+		log.Errorln("Error while connecting to", dsn)
+		panic(err)
+	}
+	return &Exporter{
+		dsn: dsn,
+		duration: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "last_scrape_duration_seconds",
+			Help:      "Duration of the last scrape of metrics from Oracle DB.",
+		}),
+		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "scrapes_total",
+			Help:      "Total number of times Oracle DB was scraped for metrics.",
+		}),
+		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "scrape_errors_total",
+			Help:      "Total number of times an error occured scraping a Oracle database.",
+		}, []string{"collector"}),
+		error: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: exporter,
+			Name:      "last_scrape_error",
+			Help:      "Whether the last scrape of metrics from Oracle DB resulted in an error (1 for error, 0 for success).",
+		}),
+		up: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "up",
+			Help:      "Whether the Oracle database server is up.",
+		}),
+		db: db,
+	}
 }
 
 // Describe describes all the metrics exported by the MS SQL exporter.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-  // We cannot know in advance what metrics the exporter will generate
-  // So we use the poor man's describe method: Run a collect
-  // and send the descriptors of all the collected metrics. The problem
-  // here is that we need to connect to the Oracle DB. If it is currently
-  // unavailable, the descriptors will be incomplete. Since this is a
-  // stand-alone exporter and not used as a library within other code
-  // implementing additional metrics, the worst that can happen is that we
-  // don't detect inconsistent metrics created by this exporter
-  // itself. Also, a change in the monitored Oracle instance may change the
-  // exported metrics during the runtime of the exporter.
+	// We cannot know in advance what metrics the exporter will generate
+	// So we use the poor man's describe method: Run a collect
+	// and send the descriptors of all the collected metrics. The problem
+	// here is that we need to connect to the Oracle DB. If it is currently
+	// unavailable, the descriptors will be incomplete. Since this is a
+	// stand-alone exporter and not used as a library within other code
+	// implementing additional metrics, the worst that can happen is that we
+	// don't detect inconsistent metrics created by this exporter
+	// itself. Also, a change in the monitored Oracle instance may change the
+	// exported metrics during the runtime of the exporter.
 
-  metricCh := make(chan prometheus.Metric)
-  doneCh := make(chan struct{})
+	metricCh := make(chan prometheus.Metric)
+	doneCh := make(chan struct{})
 
-  go func() {
-    for m := range metricCh {
-      ch <- m.Desc()
-    }
-    close(doneCh)
-  }()
+	go func() {
+		for m := range metricCh {
+			ch <- m.Desc()
+		}
+		close(doneCh)
+	}()
 
-  e.Collect(metricCh)
-  close(metricCh)
-  <-doneCh
+	e.Collect(metricCh)
+	close(metricCh)
+	<-doneCh
 
 }
 
 // Collect implements prometheus.Collector.
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-  e.scrape(ch)
-  ch <- e.duration
-  ch <- e.totalScrapes
-  ch <- e.error
-  e.scrapeErrors.Collect(ch)
-  ch <- e.up
+	e.scrape(ch)
+	ch <- e.duration
+	ch <- e.totalScrapes
+	ch <- e.error
+	e.scrapeErrors.Collect(ch)
+	ch <- e.up
 }
 
 func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
-  e.totalScrapes.Inc()
-  var err error
-  defer func(begun time.Time) {
-    e.duration.Set(time.Since(begun).Seconds())
-    if err == nil {
-      e.error.Set(0)
-    } else {
-      e.error.Set(1)
-    }
-  }(time.Now())
+	e.totalScrapes.Inc()
+	var err error
+	defer func(begun time.Time) {
+		e.duration.Set(time.Since(begun).Seconds())
+		if err == nil {
+			e.error.Set(0)
+		} else {
+			e.error.Set(1)
+		}
+	}(time.Now())
 
-  // Noop function for simple SELECT 1 FROM DUAL
-  noop := func(row map[string]string) error { return nil }
-  if err = GeneratePrometheusMetrics(e.db, noop, "SELECT 1 FROM DUAL"); err != nil {
-    log.Errorln("Error pinging oracle:", err)
-    // Maybe Oracle instance was restarted => try to reconnect
-    // fix https://github.com/iamseth/oracledb_exporter/issues/32
-    log.Infoln("Try to reconnect...")
-    e.db, err = sql.Open("oci8", e.dsn)
-    if err != nil {
-      log.Errorln("Error while connecting to oracle:", err)
-      e.up.Set(0)
-      return
-    }
-    if err = GeneratePrometheusMetrics(e.db, noop, "SELECT 1 FROM DUAL"); err != nil {
-      log.Error("Unable to connect to oracle:", err)
-      e.up.Set(0)
-      return
-    }
-  }
-  e.up.Set(1)
+	// Noop function for simple SELECT 1 FROM DUAL
+	noop := func(row map[string]string) error { return nil }
+	if err = GeneratePrometheusMetrics(e.db, noop, "SELECT 1 FROM DUAL"); err != nil {
+		log.Errorln("Error pinging oracle:", err)
+		// Maybe Oracle instance was restarted => try to reconnect
+		// fix https://github.com/iamseth/oracledb_exporter/issues/32
+		log.Infoln("Try to reconnect...")
+		e.db, err = sql.Open("oci8", e.dsn)
+		if err != nil {
+			log.Errorln("Error while connecting to oracle:", err)
+			e.up.Set(0)
+			return
+		}
+		if err = GeneratePrometheusMetrics(e.db, noop, "SELECT 1 FROM DUAL"); err != nil {
+			log.Error("Unable to connect to oracle:", err)
+			e.up.Set(0)
+			return
+		}
+	}
+	e.up.Set(1)
 
-  for _, metric := range metricsToScrap.Metric {
-    if err = ScrapeMetric(e.db, ch, metric); err != nil {
-      log.Errorln("Error scraping for", metric.Context, ":", err)
-      e.scrapeErrors.WithLabelValues(metric.Context).Inc()
-    }
-  }
+	for _, metric := range metricsToScrap.Metric {
+		if err = ScrapeMetric(e.db, ch, metric); err != nil {
+			log.Errorln("Error scraping for", metric.Context, ":", err)
+			e.scrapeErrors.WithLabelValues(metric.Context).Inc()
+		}
+	}
 
 }
 
 func GetMetricType(metricType string, metricsType map[string]string) prometheus.ValueType {
-  var strToPromType = map[string]prometheus.ValueType{
-    "gauge":       prometheus.GaugeValue,
-    "counter":     prometheus.CounterValue,
-  }
+	var strToPromType = map[string]prometheus.ValueType{
+		"gauge":   prometheus.GaugeValue,
+		"counter": prometheus.CounterValue,
+	}
 
-  strType, ok := metricsType[strings.ToLower(metricType)]
-  if !ok {
-    return prometheus.GaugeValue
-  }
-  valueType, ok := strToPromType[strings.ToLower(strType)]
-  if !ok {
-    panic(errors.New("Error while getting prometheus type " + strings.ToLower(strType)))
-  }
-  return valueType
+	strType, ok := metricsType[strings.ToLower(metricType)]
+	if !ok {
+		return prometheus.GaugeValue
+	}
+	valueType, ok := strToPromType[strings.ToLower(strType)]
+	if !ok {
+		panic(errors.New("Error while getting prometheus type " + strings.ToLower(strType)))
+	}
+	return valueType
 }
 
 // interface method to call ScrapeGenericValues using Metric struct values
 func ScrapeMetric(db *sql.DB, ch chan<- prometheus.Metric, metricDefinition Metric) error {
-  return ScrapeGenericValues(db, ch, metricDefinition.Context, metricDefinition.Labels,
-                             metricDefinition.MetricsDesc, metricDefinition.MetricsType,
-                             metricDefinition.FieldToAppend, metricDefinition.IgnoreZeroResult,
-                             metricDefinition.Request)
+	return ScrapeGenericValues(db, ch, metricDefinition.Context, metricDefinition.Labels,
+		metricDefinition.MetricsDesc, metricDefinition.MetricsType,
+		metricDefinition.FieldToAppend, metricDefinition.IgnoreZeroResult,
+		metricDefinition.Request)
 }
 
 // generic method for retrieving metrics.
 func ScrapeGenericValues(db *sql.DB, ch chan<- prometheus.Metric, context string, labels []string,
-                         metricsDesc map[string]string, metricsType map[string]string, fieldToAppend string, ignoreZeroResult bool, request string) error {
-  metricsCount := 0
-  genericParser := func(row map[string]string) error {
-    // Construct labels value
-    labelsValues := []string{}
-    for _, label := range labels {
-      labelsValues = append(labelsValues, row[label])
-    }
-    // Construct Prometheus values to sent back
-    for metric, metricHelp := range metricsDesc {
-      value, err := strconv.ParseFloat(strings.TrimSpace(row[metric]), 64)
-      // If not a float, skip current metric
-      if err != nil {
-        continue
-      }
-      // If metric do not use a field content in metric's name
-      if strings.Compare(fieldToAppend, "") == 0 {
-        desc := prometheus.NewDesc(
-          prometheus.BuildFQName(namespace, context, metric),
-          metricHelp,
-          labels, nil,
-        )
-        ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value, labelsValues...)
-      // If no labels, use metric name
-      } else {
-        desc := prometheus.NewDesc(
-          prometheus.BuildFQName(namespace, context, cleanName(row[fieldToAppend])),
-          metricHelp,
-          nil, nil,
-        )
-        ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value)
-      }
-      metricsCount ++
-    }
-    return nil
-  }
-  err := GeneratePrometheusMetrics(db, genericParser, request)
-  if err != nil {
-    return err
-  }
-  if !ignoreZeroResult && metricsCount == 0 {
-    return errors.New("No metrics found while parsing")
-  }
-  return err
+	metricsDesc map[string]string, metricsType map[string]string, fieldToAppend string, ignoreZeroResult bool, request string) error {
+	metricsCount := 0
+	genericParser := func(row map[string]string) error {
+		// Construct labels value
+		labelsValues := []string{}
+		for _, label := range labels {
+			labelsValues = append(labelsValues, row[label])
+		}
+		// Construct Prometheus values to sent back
+		for metric, metricHelp := range metricsDesc {
+			value, err := strconv.ParseFloat(strings.TrimSpace(row[metric]), 64)
+			// If not a float, skip current metric
+			if err != nil {
+				continue
+			}
+			// If metric do not use a field content in metric's name
+			if strings.Compare(fieldToAppend, "") == 0 {
+				desc := prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, context, metric),
+					metricHelp,
+					labels, nil,
+				)
+				ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value, labelsValues...)
+				// If no labels, use metric name
+			} else {
+				desc := prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, context, cleanName(row[fieldToAppend])),
+					metricHelp,
+					nil, nil,
+				)
+				ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value)
+			}
+			metricsCount++
+		}
+		return nil
+	}
+	err := GeneratePrometheusMetrics(db, genericParser, request)
+	if err != nil {
+		return err
+	}
+	if !ignoreZeroResult && metricsCount == 0 {
+		return errors.New("No metrics found while parsing")
+	}
+	return err
 }
 
 // inspired by https://kylewbanks.com/blog/query-result-to-map-in-golang
 // Parse SQL result and call parsing function to each row
 func GeneratePrometheusMetrics(db *sql.DB, parse func(row map[string]string) error, query string) error {
 
-  // Add a timeout
-  timeout, err := strconv.Atoi(*queryTimeout)
-  if err != nil {
-    log.Fatal("error while converting timeout option value: ", err)
-    panic(err)
-  }
-  ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-  defer cancel()
-  rows, err := db.QueryContext(ctx, query)
+	// Add a timeout
+	timeout, err := strconv.Atoi(*queryTimeout)
+	if err != nil {
+		log.Fatal("error while converting timeout option value: ", err)
+		panic(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+	rows, err := db.QueryContext(ctx, query)
 
-  if ctx.Err() == context.DeadlineExceeded {
-    return errors.New("Oracle query timed out")
-  }
+	if ctx.Err() == context.DeadlineExceeded {
+		return errors.New("Oracle query timed out")
+	}
 
-  if err != nil {
-    return err
-  }
-  cols, err := rows.Columns()
-  defer rows.Close()
+	if err != nil {
+		return err
+	}
+	cols, err := rows.Columns()
+	defer rows.Close()
 
-  for rows.Next() {
-    // Create a slice of interface{}'s to represent each column,
-    // and a second slice to contain pointers to each item in the columns slice.
-    columns := make([]interface{}, len(cols))
-    columnPointers := make([]interface{}, len(cols))
-    for i, _ := range columns {
-      columnPointers[i] = &columns[i]
-    }
+	for rows.Next() {
+		// Create a slice of interface{}'s to represent each column,
+		// and a second slice to contain pointers to each item in the columns slice.
+		columns := make([]interface{}, len(cols))
+		columnPointers := make([]interface{}, len(cols))
+		for i, _ := range columns {
+			columnPointers[i] = &columns[i]
+		}
 
-    // Scan the result into the column pointers...
-    if err := rows.Scan(columnPointers...); err != nil {
-      return err
-    }
+		// Scan the result into the column pointers...
+		if err := rows.Scan(columnPointers...); err != nil {
+			return err
+		}
 
-    // Create our map, and retrieve the value for each column from the pointers slice,
-    // storing it in the map with the name of the column as the key.
-    m := make(map[string]string)
-    for i, colName := range cols {
-      val := columnPointers[i].(*interface{})
-      m[strings.ToLower(colName)] = (*val).(string)
-    }
-    // Call function to parse row
-    if err := parse(m); err != nil {
-      return err
-    }
-  }
+		// Create our map, and retrieve the value for each column from the pointers slice,
+		// storing it in the map with the name of the column as the key.
+		m := make(map[string]string)
+		for i, colName := range cols {
+			val := columnPointers[i].(*interface{})
+			m[strings.ToLower(colName)] = (*val).(string)
+		}
+		// Call function to parse row
+		if err := parse(m); err != nil {
+			return err
+		}
+	}
 
-  return nil
+	return nil
 
 }
 
 // Oracle gives us some ugly names back. This function cleans things up for Prometheus.
 func cleanName(s string) string {
-  s = strings.Replace(s, " ", "_", -1) // Remove spaces
-  s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
-  s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
-  s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
-  s = strings.ToLower(s)
-  return s
+	s = strings.Replace(s, " ", "_", -1) // Remove spaces
+	s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
+	s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
+	s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
+	s = strings.ToLower(s)
+	return s
 }
 
 func main() {
-  flag.Parse()
-  log.Infoln("Starting oracledb_exporter " + Version)
-  dsn := os.Getenv("DATA_SOURCE_NAME")
-  // Load default metrics
-  if _, err := toml.DecodeFile(*defaultFileMetrics, &metricsToScrap); err != nil {
-    log.Errorln(err)
-    panic(errors.New("Error while loading " + *defaultFileMetrics))
-  }
+	flag.Parse()
+	log.Infoln("Starting oracledb_exporter " + Version)
+	dsn := os.Getenv("DATA_SOURCE_NAME")
+	// Load default metrics
+	if _, err := toml.DecodeFile(*defaultFileMetrics, &metricsToScrap); err != nil {
+		log.Errorln(err)
+		panic(errors.New("Error while loading " + *defaultFileMetrics))
+	}
 
-  // If custom metrics, load it
-  if strings.Compare(*customMetrics, "") != 0 {
-    if _, err := toml.DecodeFile(*customMetrics, &additionalMetrics); err != nil {
-      log.Errorln(err)
-      panic(errors.New("Error while loading " + *customMetrics))
-    }
-    metricsToScrap.Metric = append(metricsToScrap.Metric, additionalMetrics.Metric...)
-  }
-  exporter := NewExporter(dsn)
-  prometheus.MustRegister(exporter)
-  http.Handle(*metricPath, prometheus.Handler())
-  http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-    w.Write(landingPage)
-  })
-  log.Infoln("Listening on", *listenAddress)
-  log.Fatal(http.ListenAndServe(*listenAddress, nil))
+	// If custom metrics, load it
+	if strings.Compare(*customMetrics, "") != 0 {
+		if _, err := toml.DecodeFile(*customMetrics, &additionalMetrics); err != nil {
+			log.Errorln(err)
+			panic(errors.New("Error while loading " + *customMetrics))
+		}
+		metricsToScrap.Metric = append(metricsToScrap.Metric, additionalMetrics.Metric...)
+	}
+	exporter := NewExporter(dsn)
+	prometheus.MustRegister(exporter)
+	http.Handle(*metricPath, prometheus.Handler())
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(landingPage)
+	})
+	log.Infoln("Listening on", *listenAddress)
+	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }


### PR DESCRIPTION
This PR:
* exposes queryTimeout via an env var named QUERY_TIMEOUT.
* adds some additional text to query.timeout and custom.metrics flags to document that they are settable via env
* fixes the alpine docker build (not sure if this was already broken, or broke recently due to upstream packaging changes)

Note: there was also a `go fmt` snuck in there by my IDE. Hope that's alright!


