### PR TITLE
feat: Add flag to allow user to maxidle and max open connection on the DB connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Usage of oracledb_exporter:
        	Address to listen on for web interface and telemetry. (default ":9161")
   -web.telemetry-path string
        	Path under which to expose metrics. (default "/metrics")
+  -database.maxIdleConns string
+        Number of maximum idle connections in the connection pool. (default "0")
+  -database.maxOpenConns string
+        Number of maximum open connections in the connection pool. (default "10")
 ```
 
 # Default metrics


### PR DESCRIPTION
This feature can be useful when using a heavily loaded database or a
database that authenticates using an external mechanism. Database
connection failure may happen in those two cases. Keeping some idle
connections will prevent the exporter from going down.

We do recommend first trying with the default values since they test if
it is still possible to open a new connection.

NOTE: I did not have time yet to test the binary becasue I haven't been able to setup my workstation correctly to build the binary and test it.