### PR TITLE
Faster tablespace utilization query

### DIFF
--- a/default-metrics.toml
+++ b/default-metrics.toml
@@ -47,74 +47,67 @@ context = "tablespace"
 labels = [ "tablespace", "type" ]
 metricsdesc = { bytes = "Generic counter metric of tablespaces bytes in Oracle.", max_bytes = "Generic counter metric of tablespaces max bytes in Oracle.", free = "Generic counter metric of tablespaces free bytes in Oracle." }
 request = '''
-  SELECT
-    Z.name       as tablespace,
-    dt.contents  as type,
-    Z.bytes      as bytes,
-    Z.max_bytes  as max_bytes,
-    Z.free_bytes as free
-  FROM
+SELECT
+  df.tablespace_name       as tablespace,
+  df.type                  as type,
+  sum(df.bytes)            as bytes,
+  sum(df.max_bytes)        as max_bytes,
+  sum(f.free)              as free
+FROM
   (
     SELECT
-      X.name                   as name,
-      SUM(nvl(X.free_bytes,0)) as free_bytes,
-      SUM(X.bytes)             as bytes,
-      SUM(X.max_bytes)         as max_bytes
+      ddf.file_id,
+      dt.contents as type,
+      ddf.file_name,
+      ddf.tablespace_name,
+      TRUNC(ddf.bytes) as bytes,
+      TRUNC(GREATEST(ddf.bytes,ddf.maxbytes)) as max_bytes
     FROM
-      (
-        SELECT
-          ddf.tablespace_name as name,
-          ddf.status as status,
-          ddf.bytes as bytes,
-          sum(coalesce(dfs.bytes, 0)) as free_bytes,
-          CASE
-            WHEN ddf.maxbytes = 0 THEN ddf.bytes
-            ELSE ddf.maxbytes
-          END as max_bytes
-        FROM
-          sys.dba_data_files ddf,
-          sys.dba_tablespaces dt,
-          sys.dba_free_space dfs
-        WHERE ddf.tablespace_name = dt.tablespace_name
-        AND ddf.file_id = dfs.file_id(+)
-        GROUP BY
-          ddf.tablespace_name,
-          ddf.file_name,
-          ddf.status,
-          ddf.bytes,
-          ddf.maxbytes
-      ) X
-    GROUP BY X.name
-    UNION ALL
+      dba_data_files ddf,
+      dba_tablespaces dt
+    WHERE ddf.tablespace_name = dt.tablespace_name
+  ) df,
+  (
     SELECT
-      Y.name                   as name,
-      MAX(nvl(Y.free_bytes,0)) as free_bytes,
-      SUM(Y.bytes)             as bytes,
-      SUM(Y.max_bytes)         as max_bytes
-    FROM
+      TRUNC(SUM(bytes)) AS free,
+      file_id
+    FROM dba_free_space
+    GROUP BY file_id
+  ) f
+WHERE df.file_id = f.file_id (+)
+GROUP BY df.tablespace_name, df.type
+UNION ALL
+SELECT
+  Y.name                   as tablespace_name,
+  Y.type                   as type,
+  SUM(Y.bytes)             as bytes,
+  SUM(Y.max_bytes)         as max_bytes,
+  MAX(nvl(Y.free_bytes,0)) as free
+FROM
+  (
+    SELECT
+      dtf.tablespace_name as name,
+      dt.contents as type,
+      dtf.status as status,
+      dtf.bytes as bytes,
       (
         SELECT
-          dtf.tablespace_name as name,
-          dtf.status as status,
-          dtf.bytes as bytes,
-          (
-            SELECT
-              ((f.total_blocks - s.tot_used_blocks)*vp.value)
-            FROM
-              (SELECT tablespace_name, sum(used_blocks) tot_used_blocks FROM gv$sort_segment WHERE  tablespace_name!='DUMMY' GROUP BY tablespace_name) s,
-              (SELECT tablespace_name, sum(blocks) total_blocks FROM dba_temp_files where tablespace_name !='DUMMY' GROUP BY tablespace_name) f,
-              (SELECT value FROM v$parameter WHERE name = 'db_block_size') vp
-            WHERE f.tablespace_name=s.tablespace_name AND f.tablespace_name = dtf.tablespace_name
-          ) as free_bytes,
-          CASE
-            WHEN dtf.maxbytes = 0 THEN dtf.bytes
-            ELSE dtf.maxbytes
-          END as max_bytes
+          ((f.total_blocks - s.tot_used_blocks)*vp.value)
         FROM
-          sys.dba_temp_files dtf
-      ) Y
-    GROUP BY Y.name
-  ) Z, sys.dba_tablespaces dt
-  WHERE
-    Z.name = dt.tablespace_name
+          (SELECT tablespace_name, sum(used_blocks) tot_used_blocks FROM gv$sort_segment WHERE  tablespace_name!='DUMMY' GROUP BY tablespace_name) s,
+          (SELECT tablespace_name, sum(blocks) total_blocks FROM dba_temp_files where tablespace_name !='DUMMY' GROUP BY tablespace_name) f,
+          (SELECT value FROM v$parameter WHERE name = 'db_block_size') vp
+        WHERE f.tablespace_name=s.tablespace_name AND f.tablespace_name = dtf.tablespace_name
+      ) as free_bytes,
+      CASE
+        WHEN dtf.maxbytes = 0 THEN dtf.bytes
+        ELSE dtf.maxbytes
+      END as max_bytes
+    FROM
+      sys.dba_temp_files dtf,
+      sys.dba_tablespaces dt
+    WHERE dtf.tablespace_name = dt.tablespace_name
+  ) Y
+GROUP BY Y.name, Y.type
+ORDER BY tablespace
 '''


### PR DESCRIPTION
The tablespace query takes over 30-35 seconds most of the time we run it on our systems, so it doesn't reliably get data into the scrape. This query yields identical numbers to the existing query, but returns in less than a second.