### PR TITLE
Adding support for histograms

### DIFF
--- a/main.go
+++ b/main.go
@@ -242,7 +242,15 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 				return
 			}
 
-			// FIXME - Should check that a MetricBuckets entry exists for everything of Histogram type
+			for column, metricType := range metric.MetricsType {
+				if metricType == "histogram" {
+					_, ok := metric.MetricsBuckets[column]
+					if ! ok {
+						log.Errorln("Unable to find MetricsBuckets configuration key for metric. (metric=" + column + ")")
+						return
+					}
+				}
+			}
 
 			if err = ScrapeMetric(e.db, ch, metric); err != nil {
 				log.Errorln("Error scraping for", metric.Context, "_", metric.MetricsDesc, ":", err)

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ type Metric struct {
 	Labels           []string
 	MetricsDesc      map[string]string
 	MetricsType      map[string]string
+	MetricsBuckets   map[string]map[string]string
 	FieldToAppend    string
 	Request          string
 	IgnoreZeroResult bool
@@ -225,6 +226,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 			log.Debugln("- Metric MetricsDesc: ", metric.MetricsDesc)
 			log.Debugln("- Metric Context: ", metric.Context)
 			log.Debugln("- Metric MetricsType: ", metric.MetricsType)
+			log.Debugln("- Metric MetricsBuckets: ", metric.MetricsBuckets, "(Ignored unless Histogram type)")
 			log.Debugln("- Metric Labels: ", metric.Labels)
 			log.Debugln("- Metric FieldToAppend: ", metric.FieldToAppend)
 			log.Debugln("- Metric IgnoreZeroResult: ", metric.IgnoreZeroResult)
@@ -239,6 +241,8 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 				log.Errorln("Error scraping for query", metric.Request, ". Did you forget to define metricsdesc  in your toml file?")
 				return
 			}
+
+			// FIXME - Should check that a MetricBuckets entry exists for everything of Histogram type
 
 			if err = ScrapeMetric(e.db, ch, metric); err != nil {
 				log.Errorln("Error scraping for", metric.Context, "_", metric.MetricsDesc, ":", err)
@@ -255,6 +259,7 @@ func GetMetricType(metricType string, metricsType map[string]string) prometheus.
 	var strToPromType = map[string]prometheus.ValueType{
 		"gauge":   prometheus.GaugeValue,
 		"counter": prometheus.CounterValue,
+		"histogram": prometheus.UntypedValue,
 	}
 
 	strType, ok := metricsType[strings.ToLower(metricType)]
@@ -272,14 +277,14 @@ func GetMetricType(metricType string, metricsType map[string]string) prometheus.
 func ScrapeMetric(db *sql.DB, ch chan<- prometheus.Metric, metricDefinition Metric) error {
 	log.Debugln("Calling function ScrapeGenericValues()")
 	return ScrapeGenericValues(db, ch, metricDefinition.Context, metricDefinition.Labels,
-		metricDefinition.MetricsDesc, metricDefinition.MetricsType,
+		metricDefinition.MetricsDesc, metricDefinition.MetricsType, metricDefinition.MetricsBuckets,
 		metricDefinition.FieldToAppend, metricDefinition.IgnoreZeroResult,
 		metricDefinition.Request)
 }
 
 // generic method for retrieving metrics.
 func ScrapeGenericValues(db *sql.DB, ch chan<- prometheus.Metric, context string, labels []string,
-	metricsDesc map[string]string, metricsType map[string]string, fieldToAppend string, ignoreZeroResult bool, request string) error {
+	metricsDesc map[string]string, metricsType map[string]string, metricsBuckets map[string]map[string]string, fieldToAppend string, ignoreZeroResult bool, request string) error {
 	metricsCount := 0
 	genericParser := func(row map[string]string) error {
 		// Construct labels value
@@ -304,7 +309,33 @@ func ScrapeGenericValues(db *sql.DB, ch chan<- prometheus.Metric, context string
 					metricHelp,
 					labels, nil,
 				)
-				ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value, labelsValues...)
+				if metricsType[strings.ToLower(metric)] == "histogram" {
+					count, err := strconv.ParseUint(strings.TrimSpace(row["count"]), 10, 64)
+					if err != nil {
+						log.Errorln("Unable to convert count value to int (metric=" + metric +
+							",metricHelp=" + metricHelp + ",value=<" + row["count"] + ">)")
+						continue
+					}
+					buckets := make(map[float64]uint64)
+					for field, le := range metricsBuckets[metric] {
+						lelimit, err := strconv.ParseFloat(strings.TrimSpace(le), 64)
+						if err != nil {
+							log.Errorln("Unable to convert bucket limit value to float (metric=" + metric +
+								",metricHelp=" + metricHelp + ",bucketlimit=<" + le + ">)")
+							continue
+						}
+						counter, err := strconv.ParseUint(strings.TrimSpace(row[field]), 10, 64)
+						if err != nil {
+							log.Errorln("Unable to convert ", field, " value to int (metric=" + metric +
+								",metricHelp=" + metricHelp + ",value=<" + row[field] + ">)")
+							continue
+						}
+						buckets[lelimit] = counter
+					}
+					ch <- prometheus.MustNewConstHistogram(desc, count, value, buckets, labelsValues...)
+				} else {
+					ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value, labelsValues...)
+				}
 				// If no labels, use metric name
 			} else {
 				desc := prometheus.NewDesc(
@@ -312,7 +343,33 @@ func ScrapeGenericValues(db *sql.DB, ch chan<- prometheus.Metric, context string
 					metricHelp,
 					nil, nil,
 				)
-				ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value)
+				if metricsType[strings.ToLower(metric)] == "histogram" {
+					count, err := strconv.ParseUint(strings.TrimSpace(row["count"]), 10, 64)
+					if err != nil {
+						log.Errorln("Unable to convert count value to int (metric=" + metric +
+							",metricHelp=" + metricHelp + ",value=<" + row["count"] + ">)")
+						continue
+					}
+					buckets := make(map[float64]uint64)
+					for field, le := range metricsBuckets[metric] {
+						lelimit, err := strconv.ParseFloat(strings.TrimSpace(le), 64)
+						if err != nil {
+							log.Errorln("Unable to convert bucket limit value to float (metric=" + metric +
+								",metricHelp=" + metricHelp + ",bucketlimit=<" + le + ">)")
+							continue
+						}
+						counter, err := strconv.ParseUint(strings.TrimSpace(row[field]), 10, 64)
+						if err != nil {
+							log.Errorln("Unable to convert ", field, " value to int (metric=" + metric +
+								",metricHelp=" + metricHelp + ",value=<" + row[field] + ">)")
+							continue
+						}
+						buckets[lelimit] = counter
+					}
+					ch <- prometheus.MustNewConstHistogram(desc, count, value, buckets)
+				} else {
+					ch <- prometheus.MustNewConstMetric(desc, GetMetricType(metric, metricsType), value)
+				}
 			}
 			metricsCount++
 		}

--- a/metric-histogram-example.toml
+++ b/metric-histogram-example.toml
@@ -1,0 +1,18 @@
+[[metric]]
+context = "test_histo"
+request = "SELECT 'firstlabel' as label1, 'secondlabel' as label2, 3 as le_20, 19 as le_40, 31 as le_60, 40 as le_80, 45 as count, 123.45 as data FROM DUAL"
+metricsdesc = { data = "Histogram - sum total of all values in the data field." }
+metricstype = { data = "histogram" }
+labels = [ "label1", "label2" ]
+metricsbuckets = { data = { le_20 = "20", le_40 = "40", le_60 = "60", le_80 = "80" } }
+
+# # Yields metrics as follows:
+# # HELP oracledb_test_histo_data Histogram - sum total of all values in the data field.
+# # TYPE oracledb_test_histo_data histogram
+# oracledb_test_histo_data_bucket{label1="firstlabel",label2="secondlabel",le="20"} 3
+# oracledb_test_histo_data_bucket{label1="firstlabel",label2="secondlabel",le="40"} 19
+# oracledb_test_histo_data_bucket{label1="firstlabel",label2="secondlabel",le="60"} 31
+# oracledb_test_histo_data_bucket{label1="firstlabel",label2="secondlabel",le="80"} 40
+# oracledb_test_histo_data_bucket{label1="firstlabel",label2="secondlabel",le="+Inf"} 45
+# oracledb_test_histo_data_sum{label1="firstlabel",label2="secondlabel"} 123.45
+# oracledb_test_histo_data_count{label1="firstlabel",label2="secondlabel"} 45


### PR DESCRIPTION
I really want to be able to do some metrics with histograms. I took a stab at it below. This accomplishes that.

There's a few decisions I made that don't _exactly_ fit with the code patterns you established for counters/gauges. Specifically, in the ScrapeGenericValues section, I feel like the GetMetricType function should be more useful to determine if the metric is a Histogram, but there's no equivalent prometheus.ValueType for a histogram. So if that function were modified to support Histograms, it's likely that you wouldn't be able to use it to specify the metric type in the MustNewConstMetric calls.

There's also a bit more code duplication than I'd like since the Histograms require so much more work to prepare in the if/else block deciding about fieldToAppend.

I'm open to feedback if you think things should be structured differently.