### PR TITLE
Using `_stat` table for ASM diskgroup checks

### DIFF
--- a/default-metrics.toml
+++ b/default-metrics.toml
@@ -14,7 +14,7 @@ request="SELECT resource_name,current_utilization,CASE WHEN TRIM(limit_value) LI
 context = "asm_diskgroup"
 labels = [ "name" ]
 metricsdesc = { total = "Total size of ASM disk group.", free = "Free space available on ASM disk group." }
-request = "SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM v$asm_diskgroup"
+request = "SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM v$asm_diskgroup_stat"
 ignorezeroresult = true
 
 [[metric]]


### PR DESCRIPTION
The current `default_metrics.toml` is querying the `v$asm_diskgroup` table. While this gets what we want it is far more intensive than it needs to be on the host server and it is not what this table is meant for. This PR updates the ASM default metric to query the `v$asm_diskgroup_stat` table instead. This `_stat` table is there for the purpose of performance monitoring. Look ups are quicker and less intense on the host machine.

As it stands now, this default metric forces the host machine to perform a discovery of all ASM diskgroups in order to find any potentially new diskgroups. While this is obviously useful in some cases, for the purpose of _monitoring_ it is not useful and can be harmful if a cluster has a large number of diskgroups it needs to rediscover. [Here](https://docs.oracle.com/cd/B19306_01/server.102/b14237/dynviews_1022.htm#REFRN30361) is the relevant Oracle documentation on this table.

I have tested this and been using this `_stat` table for diskgroup metrics for the past three or four months. DBAs report that it is resulting in far less resources being used and they can see a significant difference between when `oracle_exporter` is gathering these metrics (which I have set up to use `_stat`) and when our Nagios instance does (which is using the `asm_diskgroup` table and not the `_stat` one).