### PR TITLE
Issue/trace files asm query

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,3 +443,21 @@ export DATA_SOURCE_NAME=system/oracle@myhost
 ```
 
 If using Docker, set the same variable using the -e flag.
+
+## An Oracle instance generates a lot of trace files being monitored by exporter
+
+As being said, Oracle instance may (and probably does) generate a lot of trace files alongside its alert log file, one trace file per scraping event. The trace file contains the following lines
+
+```
+...
+*** MODULE NAME:(prometheus_oracle_exporter-amd64@hostname)
+...
+kgxgncin: clsssinit: CLSS init failed with status 3
+kgxgncin: clsssinit: return status 3 (0 SKGXN not av) from CLSS
+```
+
+The root cause is Oracle's reaction of quering ASM-related views without ASM used. The current workaround proposed is to setup a regular task to cleanup these trace files from the filesystem, as example
+
+```
+$ find $ORACLE_BASE/diag/rdbms -name '*.tr[cm]' -mtime +14 -delete
+```

--- a/default-metrics.toml
+++ b/default-metrics.toml
@@ -14,7 +14,7 @@ request="SELECT resource_name,current_utilization,CASE WHEN TRIM(limit_value) LI
 context = "asm_diskgroup"
 labels = [ "name" ]
 metricsdesc = { total = "Total size of ASM disk group.", free = "Free space available on ASM disk group." }
-request = "SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM v$asm_diskgroup_stat"
+request = "SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM v$asm_diskgroup_stat where exists (select 1 from v$datafile where name like '+%')"
 ignorezeroresult = true
 
 [[metric]]


### PR DESCRIPTION
I've created a few lines of documentation describing the issue with asm-related query generating huge number of trace files if no ASM is used. Also modified the query itself to avoid accessing the view if no datafile lives on ASM diskgroup - the laziest way to provide a workaround.

The query plan now looks as following

```
PLAN_TABLE_OUTPUT
------------------------------------------------------------------------------------
SQL_ID	dbkwwtwmnt5ry, child number 0
-------------------------------------
SELECT name,total_mb*1024*1024 as total,free_mb*1024*1024 as free FROM
v$asm_diskgroup_stat where exists (select 1 from v$datafile where name
like '+%')

Plan hash value: 3491613596

----------------------------------------------------------------------------------
| Id  | Operation	  | Name	 | Starts | E-Rows | A-Rows |	A-Time	 |
----------------------------------------------------------------------------------
|   0 | SELECT STATEMENT  |		 |	1 |	   |	  0 |00:00:00.01 |
|*  1 |  FILTER 	  |		 |	1 |	   |	  0 |00:00:00.01 |
|*  2 |   FIXED TABLE FULL| X$KFGRP_STAT |	0 |	 1 |	  0 |00:00:00.01 |
|*  3 |   FIXED TABLE FULL| X$KCVDF	 |	1 |	 1 |	  0 |00:00:00.01 |
----------------------------------------------------------------------------------

Query Block Name / Object Alias (identified by operation id):
-------------------------------------------------------------

   1 - SEL$5C160134
   2 - SEL$5C160134 / G@SEL$3
   3 - SEL$F5B21678 / DF@SEL$6

Predicate Information (identified by operation id):
---------------------------------------------------

   1 - filter( IS NOT NULL)
   2 - filter(("G"."INST_ID"=USERENV('INSTANCE') AND "STATE_KFGRP"<>0 AND
	      "NUMBER_KFGRP"<>0))
   3 - filter(("DF_FNNAM" LIKE '+%' AND "INST_ID"=USERENV('INSTANCE')))

```
Number of Starts 0 for plan line id 2 means that no access  to X$KFGRP_STAT occurred, and it means that we are safe from generating a trace file of this particular type.