### PR TITLE
Use strings.ReplaceAll() rather than strings.Replace() with -1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+  - repo: https://github.com/jessp01/pre-commit-golang.git
+    rev: v0.5.9
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+      - id: go-vet
+      - id: go-lint
+      - id: go-critic
+      - id: go-ineffassign
+      - id: shellcheck

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -574,11 +574,11 @@ func getMetricType(metricType string, metricsType map[string]string) prometheus.
 }
 
 func cleanName(s string) string {
-	s = strings.Replace(s, " ", "_", -1) // Remove spaces
-	s = strings.Replace(s, "(", "", -1)  // Remove open parenthesis
-	s = strings.Replace(s, ")", "", -1)  // Remove close parenthesis
-	s = strings.Replace(s, "/", "", -1)  // Remove forward slashes
-	s = strings.Replace(s, "*", "", -1)  // Remove asterisks
+	s = strings.ReplaceAll(s, " ", "_") // Remove spaces
+	s = strings.ReplaceAll(s, "(", "")  // Remove open parenthesis
+	s = strings.ReplaceAll(s, ")", "")  // Remove close parenthesis
+	s = strings.ReplaceAll(s, "/", "")  // Remove forward slashes
+	s = strings.ReplaceAll(s, "*", "")  // Remove asterisks
 	s = strings.ToLower(s)
 	return s
 }


### PR DESCRIPTION
Hello,

Well done on creating this exporter. 

Also, added a pre-commit hook. To install it:

```
go install github.com/go-critic/go-critic/cmd/gocritic@latest go install golang.org/x/tools/cmd/goimports@latest go install golang.org/x/lint/golint@latest
go install github.com/gordonklaus/ineffassign@latest pip install pre-commit
pre-commit install
```
It will then run on every `git commit` invocation. To run manually on all files, invoke: `pre-commit run --all-files`

Following the merge of this pull, the only issue that will be reported is:
> ./main.go:85:3: exitAfterDefer: os.Exit will exit, and `defer cancel()` will not run

Please see discussion in https://github.com/go-critic/go-critic/issues/1022 for ways to address this.

Cheers,