### PR TITLE
Fix metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following metrics are exposed currently.
 - oracledb_wait_time_user_io
 - oracledb_tablespace_bytes
 - oracledb_tablespace_max_bytes
-- oracledb_tablespace_free
+- oracledb_tablespace_free_bytes
 - oracledb_tablespace_used_percent
 - oracledb_process_count
 - oracledb_resource_current_utilization

--- a/default-metrics.legacy-tablespace.toml
+++ b/default-metrics.legacy-tablespace.toml
@@ -45,14 +45,14 @@ WHERE
 [[metric]]
 context = "tablespace"
 labels = [ "tablespace", "type" ]
-metricsdesc = { bytes = "Generic counter metric of tablespaces bytes in Oracle.", max_bytes = "Generic counter metric of tablespaces max bytes in Oracle.", free = "Generic counter metric of tablespaces free bytes in Oracle." }
+metricsdesc = { bytes = "Generic counter metric of tablespaces bytes in Oracle.", max_bytes = "Generic counter metric of tablespaces max bytes in Oracle.", free_bytes = "Generic counter metric of tablespaces free bytes in Oracle." }
 request = '''
 SELECT
   df.tablespace_name       as tablespace,
   df.type                  as type,
   nvl(sum(df.bytes),0)     as bytes,
   nvl(sum(df.max_bytes),0) as max_bytes,
-  nvl(sum(f.free),0)       as free
+  nvl(sum(f.free),0)       as free_bytes
 FROM
   (
     SELECT
@@ -69,7 +69,7 @@ FROM
   ) df,
   (
     SELECT
-      TRUNC(SUM(bytes)) AS free,
+      TRUNC(SUM(bytes)) AS free_bytes,
       file_id
     FROM dba_free_space
     GROUP BY file_id
@@ -82,7 +82,7 @@ SELECT
   Y.type                   as type,
   SUM(Y.bytes)             as bytes,
   SUM(Y.max_bytes)         as max_bytes,
-  MAX(nvl(Y.free_bytes,0)) as free
+  MAX(nvl(Y.free_bytes,0)) as free_bytes
 FROM
   (
     SELECT

--- a/default-metrics.toml
+++ b/default-metrics.toml
@@ -45,14 +45,14 @@ WHERE
 [[metric]]
 context = "tablespace"
 labels = [ "tablespace", "type" ]
-metricsdesc = { bytes = "Generic counter metric of tablespaces bytes in Oracle.", max_bytes = "Generic counter metric of tablespaces max bytes in Oracle.", free = "Generic counter metric of tablespaces free bytes in Oracle.", used_percent = "Gauge metric showing as a percentage of how much of the tablespace has been used." }
+metricsdesc = { bytes = "Generic counter metric of tablespaces bytes in Oracle.", max_bytes = "Generic counter metric of tablespaces max bytes in Oracle.", free_bytes = "Generic counter metric of tablespaces free bytes in Oracle.", used_percent = "Gauge metric showing as a percentage of how much of the tablespace has been used." }
 request = '''
 SELECT
     dt.tablespace_name as tablespace,
     dt.contents as type,
     dt.block_size * dtum.used_space as bytes,
     dt.block_size * dtum.tablespace_size as max_bytes,
-    dt.block_size * (dtum.tablespace_size - dtum.used_space) as free,
+    dt.block_size * (dtum.tablespace_size - dtum.used_space) as free_bytes,
     dtum.used_percent
 FROM  dba_tablespace_usage_metrics dtum, dba_tablespaces dt
 WHERE dtum.tablespace_name = dt.tablespace_name


### PR DESCRIPTION
# Description

Prometheus metric naming best practices not followed for metric name "oracledb_tablespace_free"

Fixes #372 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Renamed the metric in toml file and I am using it in production.

## Screenshots (if appropriate):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
