### PR TITLE
Add flag for configuration DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Usage of oracledb_exporter:
         Number of maximum idle connections in the connection pool. (default "0")
   --database.maxOpenConns string
         Number of maximum open connections in the connection pool. (default "10")
+  --database.dsn string
+        Connection string to a data source. (default "env: DATA_SOURCE_NAME")
   --web.config.file
         Path to configuration file that can enable TLS or authentication.
 ```

--- a/main.go
+++ b/main.go
@@ -26,8 +26,11 @@ import (
 
 var (
 	// Version will be set at build time.
-	Version            = "0.0.0.dev"
-	metricPath         = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics. (env: TELEMETRY_PATH)").Default(getEnv("TELEMETRY_PATH", "/metrics")).String()
+	Version    = "0.0.0.dev"
+	metricPath = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics. (env: TELEMETRY_PATH)").Default(getEnv("TELEMETRY_PATH", "/metrics")).String()
+	dsn        = kingpin.Flag("database.dsn",
+		"Connection string to a data source. (env: DATA_SOURCE_NAME)",
+	).Default(getEnv("DATA_SOURCE_NAME", "")).String()
 	defaultFileMetrics = kingpin.Flag(
 		"default.metrics",
 		"File with default metrics in a TOML file. (env: DEFAULT_METRICS)",
@@ -62,10 +65,9 @@ func main() {
 	kingpin.Version(version.Print("oracledb_exporter"))
 	kingpin.Parse()
 	logger := promlog.New(promLogConfig)
-	dsn := os.Getenv("DATA_SOURCE_NAME")
 
 	config := &collector.Config{
-		DSN:                dsn,
+		DSN:                *dsn,
 		MaxOpenConns:       *maxOpenConns,
 		MaxIdleConns:       *maxIdleConns,
 		CustomMetrics:      *customMetrics,


### PR DESCRIPTION
# Description

Another way to configure DSN. 
This is relevant for Windows systems, where it is difficult to forward an environment variable

## Type of change

- [+] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It worked on Winodws with OracleDB

## Screenshots (if appropriate):
Test where dsn was output to the console
![2024-02-01 19_05_46-MINGW64__c_Users_BurtasovAA](https://github.com/iamseth/oracledb_exporter/assets/76874959/a28fe24f-8959-4943-b91e-30b4ef8b8ef7)


# Checklist:

- [+] My code follows the style guidelines of this project
- [+ ] I have performed a self-review of my own code
- [+ ] I have commented my code, particularly in hard-to-understand areas
- [+ ] I have made corresponding changes to the documentation
- [+ ] My changes generate no new warnings
- [+ ] I have added tests that prove my fix is effective or that my feature works
- [+ ] New and existing unit tests pass locally with my changes
- [+ ] Any dependent changes have been merged and published in downstream modules
- [+ ] Updated version in Makefile respecting [semver v2](https://semver.org/spec/v2.0.0.html)
