### PR TITLE
Add scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ RUN go get -d -v
 ARG VERSION
 ENV VERSION ${VERSION:-0.1.0}
 
-RUN GOOS=linux GOARCH=amd64 go build -v -ldflags "-X main.Version=${VERSION} -s -w"
+ARG CGO_ENABLED
+ENV CGO_ENABLED ${CGO_ENABLED:-1}
+
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=amd64 go build -v -ldflags "-X main.Version=${VERSION} -s -w"
 
 FROM ${BASE_IMAGE} as exporter
 LABEL org.opencontainers.image.authors="Seth Miller,Yannig Perré <yannig.perre@gmail.com>"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ RELEASE        ?= true
 UBUNTU_BASE_IMAGE       ?= docker.io/library/ubuntu:24.04
 ORACLE_LINUX_BASE_IMAGE ?= docker.io/library/oraclelinux:9-slim
 ALPINE_BASE_IMAGE       ?= docker.io/library/alpine:3.19
+SCRATCH_BASE_IMAGE      ?= scratch
 
 ifeq ($(GOOS), windows)
 EXT?=.exe
@@ -92,12 +93,13 @@ go-test:
 clean:
 	rm -rf ./dist sgerrand.rsa.pub glibc-*.apk oracle-*.rpm
 
-docker: ubuntu-image alpine-image oraclelinux-image
+docker: ubuntu-image alpine-image oraclelinux-image scratch-image
 
 push-images:
 	@make --no-print-directory push-ubuntu-image
 	@make --no-print-directory push-oraclelinux-image
 	@make --no-print-directory push-alpine-image
+	@make --no-print-directory push-scratch-image
 
 oraclelinux-image:
 	if DOCKER_CLI_EXPERIMENTAL=enabled $(DOCKER_CMD) manifest inspect "$(IMAGE_ID)-oraclelinux" > /dev/null; then \
@@ -164,6 +166,28 @@ endif
 sign-alpine-image:
 ifneq ("$(wildcard cosign.key)","")
 	cosign sign --key cosign.key $(IMAGE_ID)-alpine
+else
+	@echo "Can't find cosign.key file"
+endif
+
+scratch-image:
+	if DOCKER_CLI_EXPERIMENTAL=enabled $(DOCKER_CMD) manifest inspect "$(IMAGE_ID)-scratch" > /dev/null; then \
+		echo "Image \"$(IMAGE_ID)-scratch\" already exists on ghcr.io"; \
+	else \
+		$(DOCKER_CMD) build --progress=plain $(BUILD_ARGS) -t "$(IMAGE_ID)-scratch" --build-arg BASE_IMAGE=$(SCRATCH_BASE_IMAGE) --build-arg CGO_ENABLED=0 . && \
+		$(DOCKER_CMD) build --progress=plain $(BUILD_ARGS) $(LEGACY_TABLESPACE) --build-arg BASE_IMAGE=$(SCRATCH_BASE_IMAGE) --build-arg CGO_ENABLED=0 -t "$(IMAGE_ID)-scratch_legacy-tablespace" . && \
+		$(DOCKER_CMD) tag "$(IMAGE_ID)-scratch" "$(IMAGE_NAME):scratch"; \
+	fi
+
+push-scratch-image:
+	$(DOCKER_CMD) push $(IMAGE_ID)-scratch
+ifeq ("$(RELEASE)", "true")
+	$(DOCKER_CMD) push "$(IMAGE_NAME):scratch"
+endif
+
+sign-scratch-image:
+ifneq ("$(wildcard cosign.key)","")
+	cosign sign --key cosign.key $(IMAGE_ID)-scratch
 else
 	@echo "Can't find cosign.key file"
 endif

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Different Linux Distros:
 - `x.y.z` - Ubuntu Linux image
 - `x.y.z-oraclelinux` - Oracle Enterprise Linux image
 - `x.y.z-Alpine` - Alpine Linux image
+- `x.y.z-scratch` - Scratch image
 
 Forked Version:
 All the above docker images have a duplicate image tag ending in
@@ -449,6 +450,10 @@ You can also build only Ubuntu image:
 Or Alpine:
 
     make alpine-image
+
+Or Scratch:
+
+    make scratch-image
 
 ### Building Binaries
 


### PR DESCRIPTION
# Description

This change adds support for the Scratch image. Docker image sizes after a `make docker`:
<pre>
iamseth/oracledb_exporter                      0.6.0-oraclelinux_legacy-tablespace   25f1e02b4c1b   6 minutes ago    137MB
iamseth/oracledb_exporter                      0.6.0-oraclelinux                     4e01e343f297   6 minutes ago    137MB
iamseth/oracledb_exporter                      oraclelinux                           4e01e343f297   6 minutes ago    137MB
iamseth/oracledb_exporter                      0.6.0-alpine                          356dfb18f4a0   7 minutes ago    33.2MB
iamseth/oracledb_exporter                      alpine                                356dfb18f4a0   7 minutes ago    33.2MB
iamseth/oracledb_exporter                      0.6.0-alpine_legacy-tablespace        26d2523cd997   7 minutes ago    33.2MB
iamseth/oracledb_exporter                      0.6.0_legacy-tablespace               a76344c6e1f9   7 minutes ago    102MB
iamseth/oracledb_exporter                      0.6.0                                 504e59108b9c   7 minutes ago    102MB
iamseth/oracledb_exporter                      latest                                504e59108b9c   7 minutes ago    102MB
iamseth/oracledb_exporter                      0.6.0-scratch_legacy-tablespace       ccb9b08fa21e   22 minutes ago   25.7MB
iamseth/oracledb_exporter                      0.6.0-scratch                         7107a78ffd8a   22 minutes ago   25.7MB
iamseth/oracledb_exporter                      scratch                               7107a78ffd8a   22 minutes ago   25.7MB
</pre>

Fixes #438 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

The following was executed in order to test the change
<pre>
make scratch-image
docker run iamseth/oracledb_exporter:scratch
</pre>
In additon we have used the image internally for a few days, but with CA and TZ info included. This is mostly as we are running monitoring where TZ info most probably is a requiremt. This has not been validated.

## Screenshots (if appropriate):

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Updated version in Makefile respecting [semver v2](https://semver.org/spec/v2.0.0.html)
