### PR TITLE
Parse Dsn URL to handle user/password masking

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -325,6 +326,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 }
 
 func (e *Exporter) connect() error {
+	_, err := url.Parse(e.dsn)
+	if err != nil {
+		level.Error(e.logger).Log("malformed DSN", maskDsn(e.dsn))
+		return err
+	}
 	level.Debug(e.logger).Log("launching connection: ", maskDsn(e.dsn))
 	db, err := sql.Open("oracle", e.dsn)
 	if err != nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -328,7 +328,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 func (e *Exporter) connect() error {
 	_, err := url.Parse(e.dsn)
 	if err != nil {
-		level.Error(e.logger).Log("malformed DSN", maskDsn(e.dsn))
+		level.Error(e.logger).Log("malformed DSN: ", maskDsn(e.dsn))
 		return err
 	}
 	level.Debug(e.logger).Log("launching connection: ", maskDsn(e.dsn))

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -23,5 +23,5 @@ func TestMalformedDSNMasksUserPassword(t *testing.T) {
 	}
 	err := e.connect()
 	assert.NotNil(t, err)
-	assert.Contains(t, buf.String(), "malformedDSN=***@")
+	assert.Contains(t, buf.String(), "malformedDSN:=***@")
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,0 +1,27 @@
+package collector
+
+import (
+	"bytes"
+
+	"sync"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/common/promlog"
+	_ "github.com/sijms/go-ora/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMalformedDSNMasksUserPassword(t *testing.T) {
+	buf := bytes.Buffer{}
+	w := log.NewSyncWriter(&buf)
+	testLogger := log.NewLogfmtLogger(w)
+	e := &Exporter{
+		mu:     &sync.Mutex{},
+		dsn:    "\tuser:pass@sdfoijwef/sdfle",
+		logger: promlog.NewWithLogger(testLogger, &promlog.Config{}),
+	}
+	err := e.connect()
+	assert.NotNil(t, err)
+	assert.Contains(t, buf.String(), "malformedDSN=***@")
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/common v0.53.0
 	github.com/prometheus/exporter-toolkit v0.11.0
 	github.com/sijms/go-ora/v2 v2.8.18
+	github.com/stretchr/testify v1.8.2
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -20,10 +21,12 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
@@ -36,4 +39,5 @@ require (
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -51,7 +51,11 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/sijms/go-ora/v2 v2.8.18 h1:hrmgl0Iognh7XiYDRvFKmSgJW7J05yq7TMljravaXE0=
 github.com/sijms/go-ora/v2 v2.8.18/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
@@ -105,6 +109,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=


### PR DESCRIPTION
# Description
Parse Dsn URL before trying to connect to be avoid printing user/password. When trying to connect via a malformed Dsn URL, the exporter logs something like this:
`caller=collector.go:263 level=error errorpingingoracle:="parse \"oracle://user:password@\\oracleserver.com:1556/sdfef\": net/url: invalid control character in URL"`
As this is treated as a generic error, the maskDsn function is not used.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
A test has been added
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Updated version in Makefile respecting [semver v2](https://semver.org/spec/v2.0.0.html)
