### PR TITLE
Migrate deprecated promlog to promslog

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -180,7 +180,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix: ${{ fromJson(needs.config.outputs.deploy-pre-release-matrix) }}
-    if: ${{ !failure() && needs.release.result == 'success' && needs.config.outputs.deploy-pull-request == 'true' }}
+    if: ${{ !failure() && needs.release.result == 'success' && needs.config.outputs.deploy-pull-request == 'true' && env.FORKED == 'false' }}
     needs:
       - config
       - build
@@ -196,6 +196,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u $ --password-stdin
 
       - name: Build image
+        if: ${{ env.FORKED == 'false' }}
         id: docker-meta
         env:
           VERSION: "${{ needs.release.outputs.version }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -122,13 +122,13 @@ jobs:
           mv dist/*.tar.gz application.tar.gz
 
       - name: Upload build output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: application
           path: "./application.tar.gz"
 
       - name: Upload test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: test-coverage
           path: "./test-coverage.out"
@@ -151,7 +151,7 @@ jobs:
         run: echo "version=${{ needs.build.outputs.version }}-rc.pr-${{ env.PULL_REQUEST_NUMBER }}-${{ github.run_number }}" >> $GITHUB_OUTPUT
 
       - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: application
           path: "."

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.key
 oci8.pc
 *.skip
+test-coverage.out

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOFLAGS        := -ldflags "$(LDFLAGS) -s -w"
 BUILD_ARGS      = --build-arg VERSION=$(VERSION)
 LEGACY_TABLESPACE = --build-arg LEGACY_TABLESPACE=.legacy-tablespace
 OUTDIR          = ./dist
-LINTER_VERSION ?= v1.55.2
+LINTER_VERSION ?= v1.62.2
 LINTER_IMAGE   ?= docker.io/golangci/golangci-lint:$(LINTER_VERSION)
 
 ifeq ($(shell command -v podman 2> /dev/null),)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/go-kit/log"
-	"github.com/prometheus/common/promlog"
+	"github.com/prometheus/common/promslog"
 	_ "github.com/sijms/go-ora/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,13 +15,12 @@ import (
 func TestMalformedDSNMasksUserPassword(t *testing.T) {
 	buf := bytes.Buffer{}
 	w := log.NewSyncWriter(&buf)
-	testLogger := log.NewLogfmtLogger(w)
 	e := &Exporter{
 		mu:     &sync.Mutex{},
 		dsn:    "\tuser:pass@sdfoijwef/sdfle",
-		logger: promlog.NewWithLogger(testLogger, &promlog.Config{}),
+		logger: promslog.New(&promslog.Config{Writer: w}),
 	}
 	err := e.connect()
 	assert.NotNil(t, err)
-	assert.Contains(t, buf.String(), "malformedDSN:=***@")
+	assert.Contains(t, buf.String(), "malformed DSN\" value=***@")
 }

--- a/collector/default_metrics.go
+++ b/collector/default_metrics.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	"github.com/go-kit/log/level"
 )
 
 // needs the const if imported, cannot os.ReadFile in this case
@@ -85,12 +84,12 @@ func (e *Exporter) DefaultMetrics() Metrics {
 		if err == nil {
 			return metricsToScrape
 		}
-		level.Error(e.logger).Log("defaultMetricsFile", e.config.DefaultMetricsFile, "msg", err)
-		level.Warn(e.logger).Log("msg", "proceeding to run with default metrics")
+		e.logger.Error("defaultMetricsFile", "file", e.config.DefaultMetricsFile, "msg", err.Error())
+		e.logger.Warn("proceeding to run with default metrics")
 	}
 
 	if _, err := toml.Decode(defaultMetricsConst, &metricsToScrape); err != nil {
-		level.Error(e.logger).Log("msg", err.Error())
+		e.logger.Error(err.Error())
 		panic(errors.New("Error while loading " + defaultMetricsConst))
 	}
 	return metricsToScrape

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/iamseth/oracledb_exporter
 
-go 1.21
-toolchain go1.22.5
+go 1.22
+
+toolchain go1.23.4
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
# Description
Bumped to go v1.22. Replaced promlog with promslog due to [deprecation](https://pkg.go.dev/github.com/prometheus/common/promlog#pkg-overview)

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

```bash
make local-build
dist/oracledb_exporter-0.6.0.linux-amd64/oracledb_exporter --custom.metrics=./custom-metrics-example/custom-metrics.yaml --log.level debug
curl http://localhost:9161/metrics
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (rephrased existing ones)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Updated version in Makefile respecting [semver v2](https://semver.org/spec/v2.0.0.html)
